### PR TITLE
1.34 setup project demo world in gazebo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,3 +12,8 @@ catkin_package(
 include_directories(
     ${catkin_INCLUDE_DIRS}
 )
+
+install(
+    DIRECTORY launch
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ include_directories(
 )
 
 install(
+    DIRECTORY urdf
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+install(
     DIRECTORY launch
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/bin/build-ws.sh
+++ b/bin/build-ws.sh
@@ -16,10 +16,13 @@ if [[ 1 -le $# && "-l" == $1 ]]; then
 					     --cmake-args "-DCATKIN_ENABLE_TESTING=0"
 fi
 
-# Build all packages except 'enpm808x_final_inspection_robot' and do NOT build their tests
-catkin_make_isolated --install \
-                     --ignore-pkg enpm808x_final_inspection_robot \
-					 --cmake-args "-DCATKIN_ENABLE_TESTING=0"
+# Pass the -o option to only build this package
+if [[ ! ( 1 -le $# && "-o" == $1 ) ]]; then
+    # Build all packages except 'enpm808x_final_inspection_robot' and do NOT build their tests
+    catkin_make_isolated --install \
+                         --ignore-pkg enpm808x_final_inspection_robot \
+                         --cmake-args "-DCATKIN_ENABLE_TESTING=0"
+fi
 
 # Build only the 'enpm808x_final_inspection_robot' package and build its tests
 catkin_make_isolated --install \

--- a/launch/demo.launch
+++ b/launch/demo.launch
@@ -1,0 +1,6 @@
+<launch>
+    <!-- spawn cans at specific locations for the demo -->
+    <include file="$(find enpm808x_final_inspection_robot)/launch/spawn_cans_from_list.launch">
+        <arg name="can_args_list" value="1,-0.5,-7.0,1.0 : 1,-1.0,-7.0,1.0 : 0,-1.5,-7.0,1.0 : 1,-0.5,-9.0,1.0 : 1,-1.0,-9.0,1.0 : 1,-1.5,-9.0,1.0 : 0,-0.5,-11.0,1.0 : 1,-1.0,-11.0,1.0 : 1,-1.5,-11.0,1.0" />
+    </include>
+</launch>

--- a/launch/main.launch
+++ b/launch/main.launch
@@ -1,0 +1,36 @@
+<launch>
+    <!-- argument(s) which can be overridden -->
+    <arg name="rviz" default="false" />
+    <arg name="view_image" default="false" />
+    <arg name="robot" default="titanium" />
+    <arg name="tiago_start_pose" default="-x 0.0 -y 0.0 -z 0.0 -R 0.0 -P 0.0 -Y 0.0" />
+    <arg name="extra_gazebo_args" default="" />
+
+    <!-- launch TIAGo mapping using our arguments, which:
+         - Runs the public simulation version (allows for multiple robot types
+           and gmapping)
+         - Uses the world 'small_office', used as the demo for this project
+         - Spawns the robot at the specified Cartesian pose
+         - Tucks in the arm on start
+         - Optionally opens RViz of the navigation's sensing
+    -->
+    <include file="$(find tiago_2dnav_gazebo)/launch/tiago_mapping.launch">
+        <arg name="extra_gazebo_args" value="$(arg extra_gazebo_args)" />
+        <arg name="gzpose" value="$(arg tiago_start_pose)" />
+        <arg name="namespace" value="/" />
+        <arg name="public_sim" value="true" />
+        <arg name="recording" value="false" />
+        <arg name="robot" value="$(arg robot)" />
+        <arg name="rviz" value="$(arg rviz)" />
+        <arg name="tuck_arm" value="true" />
+        <arg name="world" value="small_office" />
+    </include>
+
+    <!-- if desired, show the TIAGo's raw image output -->
+    <node name="tiago_image_view"
+          pkg="image_view"
+          type="image_view"
+          args="image:=/xtion/rgb/image_raw"
+          if="$(arg view_image)"
+    />
+</launch>

--- a/launch/spawn_can.launch
+++ b/launch/spawn_can.launch
@@ -1,0 +1,27 @@
+<launch>
+    <!-- unique identier of the Gazebo model -->
+    <arg name="id" />
+    <!-- is the can nominal (1/'true') or defective (0/'false')? -->
+    <arg name="nominal" />
+    <!-- x-position of the Gazebo model -->
+    <arg name="x" />
+    <!-- y-position of the Gazebo model -->
+    <arg name="y" />
+    <!-- z-position of the Gazebo model -->
+    <arg name="z" />
+
+    <arg name="desc" value="$(eval 'can_' + ('nominal' if arg('nominal') else 'defective') + '_description')" />
+
+    <!-- send the URDF to the parameter server -->
+    <param name="$(arg desc)"
+           command="$(find xacro)/xacro $(find enpm808x_final_inspection_robot)/urdf/can.urdf.xacro nominal:=$(arg nominal)"
+    />
+
+    <!-- push the description to the factory and spawn the can in Gazebo -->
+    <node name="$(anon spawn_can)"
+          pkg="gazebo_ros"
+          type="spawn_model"
+          args="-urdf -param $(arg desc) -x $(arg x) -y $(arg y) -z $(arg z) -model can_model_$(arg id)"
+          respawn="false"
+    />
+</launch>

--- a/launch/spawn_cans_from_list.launch
+++ b/launch/spawn_cans_from_list.launch
@@ -1,0 +1,48 @@
+<launch>
+    <!-- argument(s) for recursion:
+         - can_list: a string of colon-separated arguments
+         - next_id: the unique ID for this can
+    -->
+    <arg name="can_args_list" />
+    <arg name="next_id" default="0" />
+
+    <!-- the index of the next delimeter (either a non-negative int if there is
+         another to process after this one, or -1 if there is not another)
+    -->
+    <arg name="i" value="$(eval arg('can_args_list').find(':'))" />
+    <!-- the arguments for a single can to be spawned -->
+    <arg name="can_args" value="$(eval (arg('can_args_list') if i == -1 else arg('can_args_list')[:i]).strip())" />
+    <!-- true if the can arguments are not an empty string, false otherwise -->
+    <arg name="valid" value="$(eval 0 != len(arg('can_args').strip()))" />
+
+    <!-- collect the can's arguments if valid -->
+    <arg name="can_nominal" value="$(eval arg('can_args').split(',')[0].strip())" if="$(arg valid)" />
+    <arg name="can_x" value="$(eval arg('can_args').split(',')[1].strip())" if="$(arg valid)" />
+    <arg name="can_y" value="$(eval arg('can_args').split(',')[2].strip())" if="$(arg valid)" />
+    <arg name="can_z" value="$(eval arg('can_args').split(',')[3].strip())" if="$(arg valid)" />
+    <!-- spawn this can if valid -->
+    <include file="$(find enpm808x_final_inspection_robot)/launch/spawn_can.launch"
+             if="$(arg valid)">
+        <arg name="id" value="$(arg next_id)" />
+        <arg name="nominal" value="$(arg can_nominal)" />
+        <arg name="x" value="$(arg can_x)" />
+        <arg name="y" value="$(arg can_y)" />
+        <arg name="z" value="$(arg can_z)" />
+    </include>
+
+    <!-- the remaining arguments to recursively issue -->
+    <arg name="remaining_args_list" value="$(eval '' if i == -1 else arg('can_args_list')[int(arg('i'))+1:])" />
+    <!-- true if the remaining arguments are not an empty string, false otherwise -->
+    <arg name="remaining_valid" value="$(eval 0 != len(arg('remaining_args_list').strip()))" />
+    <!-- recursively call this launch file if valid -->
+    <include file="$(find enpm808x_final_inspection_robot)/launch/spawn_cans_from_list.launch"
+             if="$(arg remaining_valid)">
+        <arg name="can_args_list" value="$(arg remaining_args_list)" />
+        <arg name="next_id" value="$(eval int(arg('next_id'))+1)" />
+    </include>
+
+    <!-- if this is the top-level call, add this string to the parameter server -->
+    <rosparam subst_value="True" if="$(eval 0 == arg('next_id'))">
+        /enpm808x/can_args_list: "$(arg can_args_list)"
+    </rosparam>
+</launch>

--- a/urdf/can.urdf.xacro
+++ b/urdf/can.urdf.xacro
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+    <xacro:arg name="nominal" default="1" /> <!-- boolean (0 or 1) -->
+    <xacro:property name="mass" value="1.0" /> <!-- kg -->
+    <xacro:property name="radius" value="0.05" /> <!-- meters -->
+    <xacro:property name="length" value="0.20" /> <!-- meters -->
+    <xacro:property name="color" value="${'Green' if $(arg nominal) else 'Red'}" />
+    <link name="simple_can_link">
+        <inertial>
+            <origin xyz="0 0 0" />
+            <mass value="1.0" />
+            <inertia ixx="${(mass/12)*((3*radius*radius)+(length*length))}"
+                     ixy="0.0"
+                     ixz="0.0"
+                     iyy="${(mass/12)*((3*radius*radius)+(length*length))}"
+                     iyz="0.0"
+                     izz="${(mass/2)*radius*radius}"
+            />
+        </inertial>
+        <visual>
+            <origin xyz="0 0 0" />
+            <geometry>
+                <cylinder radius="${radius}" length="${length}" />
+            </geometry>
+        </visual>
+        <collision>
+            <origin xyz="0 0 0" />
+            <geometry>
+                <cylinder radius="${radius}" length="${length}" />
+            </geometry>
+        </collision>
+    </link>
+    <gazebo reference="simple_can_link">
+        <material>Gazebo/${color}</material>
+    </gazebo>
+</robot>


### PR DESCRIPTION
Major changes include:
- Create a xacro/URDF of the 'can' that will be inspected, which is a simple cylinder
- Add a main launch file which will launch Gazebo, create a TIAGo robot and its nodes for navigation/mapping/sensing/etc., optionally an RViz for this environment, and optionally a node which will display a specified image topic for debugging
- Add a launch file for spawning a single can that's either defective or not, at a specified [x,y,z] position in meters
- Add a launch file which will recursively call itself, spawning a list of cans with characteristics specified from an input string; this allows configuration to come from a hardcoded list in a launch file (added a demo launch file like this), or passing in the contents of a file, or just launching with a dynamically typed configuration